### PR TITLE
Пример с обжатием упругопластичного цилиндра

### DIFF
--- a/anifem++/autodiff/physical_tensors.h
+++ b/anifem++/autodiff/physical_tensors.h
@@ -225,6 +225,8 @@ struct PhysMtx{
     friend PhysMtx<N, FT> operator*(FT c, const PhysMtx<N, FT>& a){ return a.operator*(c); }
     inline PhysMtx<N, FT> operator/(FT a) const { PhysMtx<N, FT> r(*this); return (r /= a); }
 
+    inline SymMtx<N, FT> Sym() const;
+
     /// @return a x a
     static inline PhysMtx<N, FT> TensorSquare(const PhysArr<N, FT>& s);
     /// @return f x s + s x f

--- a/anifem++/autodiff/physical_tensors.inl
+++ b/anifem++/autodiff/physical_tensors.inl
@@ -24,6 +24,14 @@ namespace Ani{
         for (std::size_t j = i; j < N; ++j)
             m_dat[N*i + j] = m_dat[N*j + i] = r(i, j);
     }
+    template<std::size_t N, typename FT>
+    inline SymMtx<N, FT> PhysMtx<N, FT>::Sym() const {
+        SymMtx<N, FT> A;
+        for (std::size_t i = 0; i < N; ++i)
+        for (std::size_t j = i; j < N; ++j)
+            A(i, j) = (m_dat[N*i + j] + m_dat[N*j + i]) / 2;
+        return A;
+    }
     namespace internal{
         template <std::size_t N, typename MTX, typename FT>
         FT Trace(const MTX& m){

--- a/anifem++/autodiff/physical_tensors.inl
+++ b/anifem++/autodiff/physical_tensors.inl
@@ -27,9 +27,10 @@ namespace Ani{
     template<std::size_t N, typename FT>
     inline SymMtx<N, FT> PhysMtx<N, FT>::Sym() const {
         SymMtx<N, FT> A;
-        for (std::size_t i = 0; i < N; ++i)
-        for (std::size_t j = i; j < N; ++j)
-            A(i, j) = (m_dat[N*i + j] + m_dat[N*j + i]) / 2;
+        for (auto it = A.begin(); it != A.end(); ++it){
+            auto q = it.index();
+            *it = (operator()(q.i, q.j) + operator()(q.j, q.i)) / 2;
+        }
         return A;
     }
     namespace internal{

--- a/anifem++/autodiff/physical_tensors_3d.inl
+++ b/anifem++/autodiff/physical_tensors_3d.inl
@@ -314,9 +314,10 @@ PhysMtx<3, FT>::PhysMtx(const SymMtx<3, FT>& r){
 template<typename FT>
 inline SymMtx<3, FT> PhysMtx<3, FT>::Sym() const {
     SymMtx<3, FT> A;
-    for (std::size_t i = 0; i < 3; ++i)
-    for (std::size_t j = i; j < 3; ++j)
-        A(i, j) = (m_dat[3*i + j] + m_dat[3*j + i]) / FT(2.0);
+        for (auto it = A.begin(); it != A.end(); ++it){
+            auto q = it.index();
+            *it = (operator()(q.i, q.j) + operator()(q.j, q.i)) / 2;
+        }
     return A;
 }
 template<typename FT>
@@ -579,15 +580,13 @@ BiSymTensor4Rank<3, FT> BiSymTensor4Rank<3, FT>::TensorSymMul2(const SymMtx<3, F
     }
     return r;
 }
-// I_ijkl = (\delta_ik \delta_jl + \delta_il \delta_kl) / 2
+// I_ijkl = (\delta_ik \delta_jl + \delta_il \delta_jk) / 2
 template<typename FT>
 BiSymTensor4Rank<3, FT> BiSymTensor4Rank<3, FT>::Identity(FT val){
     BiSymTensor4Rank<3, FT> r;
-    for (auto it = r.begin(); it != r.end(); ++it){
-        auto q = it.index();
-        *it = ((q.i == q.k && q.j == q.l ? val : FT(0)) +
-                   (q.i == q.l && q.j == q.k ? val : FT(0))) / 2.0;
-    }
+       r(0, 0, 0, 0) = r(1, 1, 1, 1) = r(2, 2, 2, 2) = val    ;
+       r(0, 1, 0, 1) = r(0, 2, 0, 2) = r(1, 2, 1, 2) = val / 2;
+       r(0, 1, 1, 0) = r(0, 2, 2, 0) = r(1, 2, 2, 1) = val / 2;
     return r;
 }
 

--- a/anifem++/autodiff/physical_tensors_3d.inl
+++ b/anifem++/autodiff/physical_tensors_3d.inl
@@ -586,7 +586,6 @@ BiSymTensor4Rank<3, FT> BiSymTensor4Rank<3, FT>::Identity(FT val){
     BiSymTensor4Rank<3, FT> r;
        r(0, 0, 0, 0) = r(1, 1, 1, 1) = r(2, 2, 2, 2) = val    ;
        r(0, 1, 0, 1) = r(0, 2, 0, 2) = r(1, 2, 1, 2) = val / 2;
-       r(0, 1, 1, 0) = r(0, 2, 2, 0) = r(1, 2, 2, 1) = val / 2;
     return r;
 }
 

--- a/anifem++/fem/fem_memory.h
+++ b/anifem++/fem/fem_memory.h
@@ -112,7 +112,7 @@ namespace Ani{
             for (std::size_t j = 0; j < A.nCol; ++j) 
                 for (std::size_t i = 0; i < A.nRow; ++i) 
                     nrm += A(i, j) * A(i, j);
-            nrm = sqrt(nrm)*abs(a);
+            nrm = sqrt(nrm)*fabs(a);
         }
         return nrm;
     }

--- a/anifem++/fem/fem_space.h
+++ b/anifem++/fem/fem_space.h
@@ -247,12 +247,12 @@ namespace Ani{
 
         BandDenseMatrixX<> operator()(AniMemoryX<> &mem, ArrayView<> &U) const override { return m_space->applyOP(m_op, mem, U); }
         OpMemoryRequirements getMemoryRequirements(uint nquadpoints, uint fusion = 1) const override { return m_space->memOP(m_op, nquadpoints, fusion); }
-        uint Nfa() const { return m_nfa; }
-        uint Dim() const { return m_dim; }
-        uint Order() const { return m_order; }
-        uint ActualType() const { return 2; }
-        bool operator==(const ApplyOpBase& otherOp) const { return otherOp.ActualType() == ActualType() && m_space == static_cast<const ApplyOpFromSpaceView&>(otherOp).m_space && m_op == static_cast<const ApplyOpFromSpaceView&>(otherOp).m_op; }
-        std::shared_ptr<ApplyOpBase> Copy() const { return std::make_shared<ApplyOpFromSpaceView>(*this); } 
+        uint Nfa() const override { return m_nfa; }
+        uint Dim() const override { return m_dim; }
+        uint Order() const override { return m_order; }
+        uint ActualType() const override { return 2; }
+        bool operator==(const ApplyOpBase& otherOp) const override { return otherOp.ActualType() == ActualType() && m_space == static_cast<const ApplyOpFromSpaceView&>(otherOp).m_space && m_op == static_cast<const ApplyOpFromSpaceView&>(otherOp).m_op; }
+        std::shared_ptr<ApplyOpBase> Copy() const override { return std::make_shared<ApplyOpFromSpaceView>(*this); }
 
         ApplyOpFromSpaceView() = default;
         ApplyOpFromSpaceView(OperatorType op, const BaseFemSpace* sp): m_space{sp}, m_op{op}, m_dim{sp->dimOP(op)}, m_nfa{sp->dofMap().NumDofOnTet()}, m_order{sp->orderOP(op)} {}
@@ -359,7 +359,7 @@ namespace Ani{
         explicit UnionFemSpace(std::vector<std::shared_ptr<BaseFemSpace>> subsets): m_subsets(std::move(subsets)){ setup(); }
         UnionFemSpace& Init(std::vector<std::shared_ptr<BaseFemSpace>> subsets);
         BaseTypes gatherType() const final { return BaseFemSpace::BaseTypes::UnionType; }
-        std::shared_ptr<BaseFemSpace> subSpace(const int* ext_dims, int ndims) const;
+        std::shared_ptr<BaseFemSpace> subSpace(const int* ext_dims, int ndims) const override;
         std::shared_ptr<BaseFemSpace> copy() const override { return std::make_shared<UnionFemSpace>(*this); }
         std::string typeName() const override;
         bool operator==(const BaseFemSpace& other) const override;
@@ -439,9 +439,9 @@ namespace Ani{
         std::string typeName() const { return m_invoker ? m_invoker->typeName() : ""; }
         bool operator==(const FemSpace& other) const { return m_invoker.get() == other.m_invoker.get() || (m_invoker && other.m_invoker && *m_invoker == *other.m_invoker); }
         
-        /// @brief Check wheather the object store some actual fem space 
+        /// @brief Check whether the object store some actual fem space 
         bool isValid() const { return m_invoker != nullptr; }
-        /// @brief Get dimesion of the fem space
+        /// @brief Get dimension of the fem space
         uint dim() const { return m_invoker->dim(); }
         /// @brief Get polynomial order of the fem space
         uint order() const { return m_invoker->order(); }
@@ -592,7 +592,7 @@ namespace Ani{
     inline static FemSpace make_complex_with_simplification(const std::vector<FemSpace>& spaces);
     inline static FemSpace pow(const FemSpace& d, int k) { return d^k; } 
 
-    /// Apply operator from space with space ownship 
+    /// Apply operator from space with space ownership 
     struct ApplyOpFromSpace: public ApplyOpBase{
         FemSpace m_space;
         OperatorType m_op = IDEN; 
@@ -607,7 +607,7 @@ namespace Ani{
         uint Order() const override { return m_order; }
         uint ActualType() const override { return 3; }
         bool operator==(const ApplyOpBase& otherOp) const override { return otherOp.ActualType() == ActualType() && m_space == static_cast<const ApplyOpFromSpace&>(otherOp).m_space && m_op == static_cast<const ApplyOpFromSpace&>(otherOp).m_op; }
-        std::shared_ptr<ApplyOpBase> Copy() const { return std::make_shared<ApplyOpFromSpace>(*this); } 
+        std::shared_ptr<ApplyOpBase> Copy() const override { return std::make_shared<ApplyOpFromSpace>(*this); }
         ApplyOpFromSpace(OperatorType op, const FemSpace& sp): m_space{sp}, m_op{op}, m_dim{sp.dimOP(op)}, m_nfa{sp.dofMap().NumDofOnTet()}, m_order{sp.orderOP(op)} {}
         ApplyOpFromSpace(const ApplyOpFromSpace&) = default;
         ApplyOpFromSpace(ApplyOpFromSpace&&) = default;

--- a/anifem++/fem/operators.h
+++ b/anifem++/fem/operators.h
@@ -420,7 +420,7 @@ namespace Ani{
         uint Order() const override { return m_order; }
         uint ActualType() const override { return 1; }
         bool operator==(const ApplyOpBase& otherOp) const override { return otherOp.ActualType() == ActualType() && m_unique_label == static_cast<const ApplyOpCustom&>(otherOp).m_unique_label; }
-        std::shared_ptr<ApplyOpBase> Copy() const { return std::make_shared<ApplyOpCustom>(*this); }
+        std::shared_ptr<ApplyOpBase> Copy() const override { return std::make_shared<ApplyOpCustom>(*this); }
     };
     /// @brief Generator of ApplyOp from templated spaces, shouldn't used in working codes, just helper for testing
     template<int OPERATOR, typename FEM_TYPE>

--- a/anifem++/fem/spaces/common.h
+++ b/anifem++/fem/spaces/common.h
@@ -80,7 +80,7 @@ namespace Ani{
             res.dSize = fusion*Operator<IDEN, FemFix<FEM_TYPE>>::Dim::value;
             return res;
         }
-        void interpolateOnDOF(const Tetra<const double>& XYZ, const EvalFunc& f, ArrayView<>* udofs, int idof_on_tet, int fusion, PlainMemoryX<> wmem, void* user_data = nullptr, uint max_quad_order = 5) const{
+        void interpolateOnDOF(const Tetra<const double>& XYZ, const EvalFunc& f, ArrayView<>* udofs, int idof_on_tet, int fusion, PlainMemoryX<> wmem, void* user_data = nullptr, uint max_quad_order = 5) const override {
             assert(wmem.ge(interpolateOnDOF_mem_req(idof_on_tet, fusion, max_quad_order)) && "Not enough of work memory");
             double* mem = wmem.ddata; //[fusion*Operator<IDEN, FemFix<FEM_TYPE>>::Dim::value]
             Dof<FemFix<FEM_TYPE>>::interpolate(XYZ, f, mem, udofs, idof_on_tet, fusion, user_data, max_quad_order);

--- a/anifem++/fem/tetdofmap.cpp
+++ b/anifem++/fem/tetdofmap.cpp
@@ -356,7 +356,7 @@ std::pair<uint, DofT::LocSymOrder> DofT::UniteDofMap::TetDofIDExt(LocGeomOrder d
 uint DofT::UniteDofMap::GetGeomMask() const{
     uint res = 0;
     for (int i = 0; i < NGEOM_TYPES; ++i) 
-        res |= ((m_shiftTetDof[i+1] - m_shiftTetDof[i]) != 0) ? (1 << i) : 0;
+        res |= ((m_shiftTetDof[i+1] - m_shiftTetDof[i]) != 0) ? NumToGeomType(i) : 0;
     return res;    
 }
 void DofT::UniteDofMap::IncrementByGeomSparsity(const TetGeomSparsity& sp, LocalOrder& lo, bool preferGeomOrdering) const{

--- a/anifem++/fem/tetdofmap.h
+++ b/anifem++/fem/tetdofmap.h
@@ -414,10 +414,10 @@ namespace Ani{
             uint GetGeomMask() const override { return base()->GetGeomMask(); }
             virtual void Clear(){ std::fill(m_shiftNumDof.begin(), m_shiftNumDof.end(), 0); m_shiftOnTet = 0; }
             uint NestedDim() const override { return 1; }
-            bool operator==(const BaseDofMap& other) const;
+            bool operator==(const BaseDofMap& other) const override;
 
-            void BeginByGeomSparsity(const TetGeomSparsity& sp, LocalOrder& lo, bool preferGeomOrdering = false) const;
-            void IncrementByGeomSparsity(const TetGeomSparsity& sp, LocalOrder& lo, bool preferGeomOrdering = false) const;
+            void BeginByGeomSparsity(const TetGeomSparsity& sp, LocalOrder& lo, bool preferGeomOrdering = false) const override;
+            void IncrementByGeomSparsity(const TetGeomSparsity& sp, LocalOrder& lo, bool preferGeomOrdering = false) const override;
         };
 
         /// A special representation to work with a subvector of d.o.f.s distributed in enclosing vector of a given subspace 
@@ -430,11 +430,11 @@ namespace Ani{
             const BaseDofMap* base() const override { return m_base.get(); }
             void set_base(const std::shared_ptr<BaseDofMap>& new_base) override { m_base = new_base; }
             void set_base(const BaseDofMap* new_base) override { m_base = new_base->Copy(); }
-            uint ActualType() const { return static_cast<uint>(BaseTypes::NestedType); }
-            void Clear(){ m_base = nullptr; NestedDofMapBase::Clear(); }
-            void GetNestedComponent(const int* ext_dims, int ndims, NestedDofMapBase& view) const;
-            std::shared_ptr<const BaseDofMap> GetSubDofMap(const int* ext_dims, int ndims) const;
-            std::shared_ptr<BaseDofMap> GetSubDofMap(const int* ext_dims, int ndims);
+            uint ActualType() const override { return static_cast<uint>(BaseTypes::NestedType); }
+            void Clear() override { m_base = nullptr; NestedDofMapBase::Clear(); }
+            void GetNestedComponent(const int* ext_dims, int ndims, NestedDofMapBase& view) const override;
+            std::shared_ptr<const BaseDofMap> GetSubDofMap(const int* ext_dims, int ndims) const override;
+            std::shared_ptr<BaseDofMap> GetSubDofMap(const int* ext_dims, int ndims) override;
 
             std::shared_ptr<BaseDofMap> Copy() const override { return std::make_shared<NestedDofMap>(*this); }
         };
@@ -447,11 +447,11 @@ namespace Ani{
             const BaseDofMap* base() const override { return m_base; }
             void set_base(const std::shared_ptr<BaseDofMap>& new_base) override { m_base = new_base.get(); }
             void set_base(const BaseDofMap* new_base) override { m_base = new_base; }
-            uint ActualType() const { return static_cast<uint>(BaseTypes::NestedViewType); }
-            void Clear(){ m_base = nullptr; NestedDofMapBase::Clear(); }
-            void GetNestedComponent(const int* ext_dims, int ndims, NestedDofMapBase& view) const;
-            std::shared_ptr<const BaseDofMap> GetSubDofMap(const int* ext_dims, int ndims) const;
-            std::shared_ptr<BaseDofMap> GetSubDofMap(const int* ext_dims, int ndims);
+            uint ActualType() const override { return static_cast<uint>(BaseTypes::NestedViewType); }
+            void Clear() override { m_base = nullptr; NestedDofMapBase::Clear(); }
+            void GetNestedComponent(const int* ext_dims, int ndims, NestedDofMapBase& view) const override;
+            std::shared_ptr<const BaseDofMap> GetSubDofMap(const int* ext_dims, int ndims) const override;
+            std::shared_ptr<BaseDofMap> GetSubDofMap(const int* ext_dims, int ndims) override;
 
             std::shared_ptr<BaseDofMap> Copy() const override { return std::make_shared<NestedDofMapView>(*this); }
         };
@@ -605,14 +605,14 @@ namespace Ani{
             uchar SymComponents(uchar etype) const override { return base->SymComponents(etype); }
             std::pair<uint, LocSymOrder> TetDofIDExt(LocGeomOrder dof_id) const override;
             bool DefinedOn(uchar etype) const override { return m_dim ? base->DefinedOn(etype) : false; }
-            uint GetGeomMask() const { return m_dim ? base->GetGeomMask() : UNDEF; }
+            uint GetGeomMask() const override { return m_dim ? base->GetGeomMask() : UNDEF; }
             uint NestedDim() const override { return m_dim; }
-            void GetNestedComponent(const int* ext_dims, int ndims, NestedDofMapBase& view) const;
-            std::shared_ptr<BaseDofMap> GetSubDofMap(const int* ext_dims, int ndims);
+            void GetNestedComponent(const int* ext_dims, int ndims, NestedDofMapBase& view) const override;
+            std::shared_ptr<BaseDofMap> GetSubDofMap(const int* ext_dims, int ndims) override;
             bool operator==(const BaseDofMap& other) const override;
             std::shared_ptr<BaseDofMap> Copy() const override { return std::make_shared<VectorDofMap>(*this); }
             
-            void IncrementByGeomSparsity(const TetGeomSparsity& sp, LocalOrder& lo, bool preferGeomOrdering = false) const;
+            void IncrementByGeomSparsity(const TetGeomSparsity& sp, LocalOrder& lo, bool preferGeomOrdering = false) const override;
             ComponentTetOrder ComponentID(TetOrder dof_id) const { return {dof_id, dof_id % base->NumDofOnTet(), dof_id / base->NumDofOnTet()}; }
             ComponentElemOrder ComponentID(ElemOrder dof_id) const { auto nd = base->NumDof(dof_id.etype); return {dof_id.etype, dof_id.gid, dof_id.gid % nd, dof_id.gid / nd};  }
         };

--- a/anifem++/fem/tetdofmap.inl
+++ b/anifem++/fem/tetdofmap.inl
@@ -184,17 +184,17 @@ namespace FemComDetails{
         std::array<uint, NGEOM_TYPES> NumDofsOnTet() const override { auto r = m_base.NumDofsOnTet(); for(auto& x: r) x *= m_dim; return r; }
         uint TypeOnTet(uint dof) const override { return m_base.TypeOnTet(dof % m_base.NumDofOnTet()); }
         bool DefinedOn(uchar etype) const override { return m_base.DefinedOn(etype); }
-        uint GetGeomMask() const { return m_base.GetGeomMask(); }
+        uint GetGeomMask() const override { return m_base.GetGeomMask(); }
         uint NestedDim() const override { return m_dim; }
 
         LocalOrder LocalOrderOnTet(TetOrder dof_id) const override;
         uint TetDofID(LocGeomOrder dof_id) const override;
         uchar SymComponents(uchar etype) const override { return m_base.SymComponents(etype); }
         std::pair<uint, LocSymOrder> TetDofIDExt(LocGeomOrder dof_id) const override;
-        void GetNestedComponent(const int* ext_dims, int ndims, NestedDofMapBase& view) const;
-        std::shared_ptr<BaseDofMap> GetSubDofMap(const int* ext_dims, int ndims);
+        void GetNestedComponent(const int* ext_dims, int ndims, NestedDofMapBase& view) const override;
+        std::shared_ptr<BaseDofMap> GetSubDofMap(const int* ext_dims, int ndims) override;
         bool operator==(const BaseDofMap& other) const override;
-        void IncrementByGeomSparsity(const TetGeomSparsity& sp, LocalOrder& lo, bool preferGeomOrdering = false) const;
+        void IncrementByGeomSparsity(const TetGeomSparsity& sp, LocalOrder& lo, bool preferGeomOrdering = false) const override;
 
         std::shared_ptr<BaseDofMap> Copy() const override { return std::make_shared<VectorDofMapCImpl<true, DofMapT>>(*this); }
     };

--- a/anifem++/inmost_interface/assembler.inl
+++ b/anifem++/inmost_interface/assembler.inl
@@ -153,9 +153,9 @@ bool AssemblerT<Traits>::fill_assemble_templates(
             auto edim = DofT::GeomTypeDim(tl.etype);
             char sign = 1;
             if (tl.etype & (DofT::EDGE_ORIENT | DofT::FACE_ORIENT)){
-                if (esigns[tl.nelem + (edim > 1) ? 6 : 0] == 0)
-                    esigns[tl.nelem + (edim > 1) ? 6 : 0] = isPositivePermutationOrient(tl.etype, tl.nelem, canonical_node_indexes) ? 1 : -1;
-                sign = esigns[tl.nelem + (edim > 1) ? 6 : 0];
+                if (esigns[tl.nelem + ((edim > 1) ? 6 : 0)] == 0)
+                    esigns[tl.nelem + ((edim > 1) ? 6 : 0)] = isPositivePermutationOrient(tl.etype, tl.nelem, canonical_node_indexes) ? 1 : -1;
+                sign = esigns[tl.nelem + ((edim > 1) ? 6 : 0)];
             }
             auto reordered_lsid = DofT::DofSymmetries::index_on_reorderd_elem(tl.etype, tl.nelem, tl.stype, tl.lsid, canonical_node_indexes); 
             auto elem = INMOST::Element(m, h[edim][tl.nelem]);

--- a/anifem++/inmost_interface/func_wrap.h
+++ b/anifem++/inmost_interface/func_wrap.h
@@ -109,7 +109,7 @@ namespace Ani{
         };
 
         ///Make numerical evaluation
-        ///@param args is working array of const Real pointers, first n_in() elements is pointers on some input parameters
+        ///@param args is working array of const Real pointers, first n_in() elements are pointers on some input parameters
         ///@param res is working array of Real pointers, first n_out() elements will contain pointers of result matrices
         ///@param iw is working integer data
         ///@param w is working real data
@@ -300,7 +300,7 @@ namespace Ani{
             m_user_data_required{with_user_data}, m_dyn_mem_required{use_dyn_mem} {}   
 
         std::vector<MatSparsity<Int>> m_sp_in, m_sp_out;
-        std::function<int(const Real** args, Real** res, Real* w, Int* iw, void* user_data, Ani::DynMem<Real, Int>* dyn_mem)> m_f;
+        Functor m_f;
         mutable DynMemParallel<Real, Int, ThreadPar::mutex<ParType>> m_mem;
         size_t m_sz_w = 0, m_sz_iw = 0;
         bool m_user_data_required = true, m_dyn_mem_required = true;

--- a/anifem++/inmost_interface/func_wrap.h
+++ b/anifem++/inmost_interface/func_wrap.h
@@ -243,7 +243,7 @@ namespace Ani{
     struct MatFuncWrapDynamic: public MatFuncWrap<TReal, TInt>{
         using Real = TReal;
         using Int = TInt;
-        using Functor = std::function<int(const Real**, Real**, Real*, Int*, void*, DynMem<Real, Int>*)>;
+        using Functor = std::function<int(const Real** args, Real** res, Real* w, Int* iw, void* user_data, Ani::DynMem<Real, Int>* dyn_mem)>;
         struct IOData{
             const Real** args;
             Real** res;

--- a/anifem++/inmost_interface/global_enumerator.h
+++ b/anifem++/inmost_interface/global_enumerator.h
@@ -373,7 +373,7 @@ struct SimpleEnumerator: public IGlobEnumeration{
     void Clear() override;
     EnumerateIndex OrderC(const NaturalIndex& physIndex) const override;
     EnumerateIndex operator()(const NaturalIndex& physIndex) const override;
-    NaturalIndex operator()(EnumerateIndex vi) const;
+    NaturalIndex operator()(EnumerateIndex vi) const override;
 
     SimpleEnumerator() = default;
     SimpleEnumerator(ASSEMBLING_TYPE t): m_t(t) {}
@@ -416,15 +416,15 @@ struct GlobEnumeration: public IGlobEnumeration{
     GlobEnumeration& setBaseEnumerator(typename std::enable_if<std::is_base_of<IGlobEnumeration, GlobEnumerationT>::value>::type* = 0){ m_t = NOSPECIFIED; return m_invoker = std::make_unique<GlobEnumerationT>(), *this; }
 
     INMOST::Storage::integer GNodeIndex(const INMOST::Node& n) const override { return m_invoker->GNodeIndex(n); }
-    void Clear(){ if (m_invoker) m_invoker->Clear(); m_invoker.reset(); }
-    EnumerateIndex OrderC(const NaturalIndex& physIndex) const{ return m_invoker->OrderC(physIndex); }
-    EnumerateIndex operator()(const NaturalIndex& physIndex) const{ return m_invoker->operator()(physIndex); }
-    NaturalIndex operator()(EnumerateIndex vi) const { return m_invoker->operator()(vi); }
+    void Clear() override { if (m_invoker) m_invoker->Clear(); m_invoker.reset(); }
+    EnumerateIndex OrderC (const NaturalIndex& physIndex) const override { return m_invoker->OrderC(physIndex); }
+    EnumerateIndex operator()(const NaturalIndex& physIndex) const override { return m_invoker->operator()(physIndex); }
+    NaturalIndex operator()(EnumerateIndex vi) const override { return m_invoker->operator()(vi); }
 
     GlobEnumeration() = default;
     GlobEnumeration(ASSEMBLING_TYPE t) { setAssemblingType(t); }
 
-    void setup();
+    void setup() override;
 };
 
 }

--- a/anifem++/kinsol_interface/SUNNonlinearSolver.cpp
+++ b/anifem++/kinsol_interface/SUNNonlinearSolver.cpp
@@ -254,7 +254,10 @@ static void* _N_VGetCommunicator_Inmost_internals(N_Vector v){
 template<typename T = INMOST_MPI_Comm, typename std::enable_if<std::is_pointer<T>::value, char>::type* = nullptr>
 static void*  _N_VGetCommunicator_Inmost_internals(N_Vector v){
 #ifdef USE_MPI
-    return NV_DATA_P(v)->GetCommunicator();
+    //return NV_DATA_P(v)->GetCommunicator();
+    static INMOST_MPI_Comm comm;
+    comm = NV_DATA_P(v)->GetCommunicator();
+    return &comm;
 #else
     (void) v;
     return NULL;

--- a/anifem++/utils/mesh_utils.cpp
+++ b/anifem++/utils/mesh_utils.cpp
@@ -182,14 +182,11 @@ void RepartMesh(Mesh* m, bool verbose){
         if (verbose && pRank  == 0)    std::cout<<"- Perform mesh partition"<<std::endl;
         p->Evaluate();
         delete p;
-        BARRIER
-
         // prior exchange ghost to get optimization in Redistribute
         m->ExchangeGhost(1, NODE); //<- required for parallel fem
         m->Redistribute();
-        BARRIER;
-        m->ExchangeGhost(1, NODE); //<- required for parallel fem
         m->ReorderEmpty(CELL | FACE | EDGE | NODE);
+        m->ExchangeGhost(1, NODE); //<- required for parallel fem
     }
 #else
     if(pCount >1) {

--- a/data/mesh/thick_cylinder.geo
+++ b/data/mesh/thick_cylinder.geo
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4f454d01dbbf11003ed951b60b2826f3e16cfb8fb4127129344a58c9b8ddcbeb
+size 500

--- a/data/mesh/thick_cylinder.msh
+++ b/data/mesh/thick_cylinder.msh
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:524bfc22e1b31c31d0afb4bc6f8066871192a12fafe360c48507972252be3bb2
+size 216653

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -6,7 +6,7 @@ if (WITH_INMOST)
     #add_subdirectory(Diffusion)
 
 endif()
-#add_subdirectory(Fem)
+add_subdirectory(Fem)
 
 
 

--- a/examples/Fem/Ani/BendBeam.cpp
+++ b/examples/Fem/Ani/BendBeam.cpp
@@ -5,11 +5,10 @@
 
 #include "inmost.h"
 #include "anifem++/utils/utils.h"
-#include "carnum/MeshGen/mesh_gen.h"
-#include "carnum/Fem/AniInterface/Fem3Dtet.h"
-#include "carnum/Fem/AniInterface/ForAssembler.h"
-#include "carnum/Fem/Assembler.h"
-#include "carnum/Solver/SUNNonlinearSolver.h"
+#include "anifem++/fem/operations/eval.h"
+#include "anifem++/inmost_interface/elemental_assembler.h"
+#include "anifem++/inmost_interface/assembler.h"
+#include "anifem++/kinsol_interface/SUNNonlinearSolver.h"
 #include <numeric>
 #if __cplusplus >= 201703L
 #include <filesystem>
@@ -155,8 +154,8 @@ struct ProblemDefinition{
             auto Var0Helper = GenerateHelper<UFem>(),
                  Var1Helper = GenerateHelper<PFem>();
             FemExprDescr fed;
-            fed.PushVar(Var0Helper, "u"); fed.PushTestFunc(Var0Helper, "phi_u");
-            fed.PushVar(Var1Helper, "p"); fed.PushTestFunc(Var1Helper, "phi_p");
+            fed.PushTrialFunc(Var0Helper, "u"); fed.PushTestFunc(Var0Helper, "phi_u");
+            fed.PushTrialFunc(Var1Helper, "p"); fed.PushTestFunc(Var1Helper, "phi_p");
             discr.SetProbDescr(std::move(fed));
         }
         discr.SetDataGatherer(get_local_data_gatherer());
@@ -768,14 +767,14 @@ struct ProblemDefinition{
             for (int i = 0; i < 4; ++i)
                 data.nlbl[i] = (*p.nodes)[i].Integer(Label);
             for (int i = 0; i < 4; ++i)
-                data.flbl[i] = (*p.faces)[p.local_face_index[i]].Integer(Label);
+                data.flbl[i] = (*p.faces)[i].Integer(Label);
             for (int i = 0; i < 6; ++i)    
-                data.elbl[i] = (*p.edges)[p.local_edge_index[i]].Integer(Label);
+                data.elbl[i] = (*p.edges)[i].Integer(Label);
             
 
             double vardat[2*unfa];
-            data.udofs.Init(p.vars->initValues.data() + p.vars->base_MemOffsets[0], unfa); 
-            data.pdofs.Init(p.vars->initValues.data() + p.vars->base_MemOffsets[1], pnfa);
+            data.udofs.Init(p.vars->begin(0), unfa);
+            data.pdofs.Init(p.vars->begin(1), pnfa);
             data.um1dofs.Init(vardat, unfa), data.um2dofs.Init(vardat+unfa, unfa);
             Tag utag = up[0];
 

--- a/examples/Fem/Ani/StokesNavier.cpp
+++ b/examples/Fem/Ani/StokesNavier.cpp
@@ -5,10 +5,10 @@
 
 #include "inmost.h"
 #include "anifem++/utils/utils.h"
-#include "carnum/MeshGen/mesh_gen.h"
-#include "carnum/Fem/AniInterface/Fem3Dtet.h"
-#include "carnum/Fem/AniInterface/ForAssembler.h"
-#include "carnum/Fem/Assembler.h"
+#include "anifem++/fem/operations/eval.h"
+#include "anifem++/inmost_interface/elemental_assembler.h"
+#include "anifem++/inmost_interface/assembler.h"
+#include "anifem++/kinsol_interface/SUNNonlinearSolver.h"
 #include <numeric>
 #if __cplusplus >= 201703L
 #include <filesystem>
@@ -457,7 +457,7 @@ int main(int argc, char* argv[]){
             ProbData data;
             for (int i = 0; i < 4; ++i) {
                 data.nlbl[i] = (*p.nodes)[i].Integer(Label);
-                //data.flbl[i] = (*p.nodes)[p.local_face_index[i]].Integer(BndLabel);
+                //data.flbl[i] = (*p.nodes)[i].Integer(BndLabel);
             }
             data.uprev.Init(udat, Operator<IDEN, UFem>::Nfa::value);
             ElementalAssembler::GatherDataOnElement(up, p, udat, 0);
@@ -473,8 +473,8 @@ int main(int argc, char* argv[]){
             auto Var0Helper = GenerateHelper<UFem>(),
                  Var1Helper = GenerateHelper<PFem>();
             FemExprDescr fed;
-            fed.PushVar(Var0Helper, "u"); fed.PushTestFunc(Var0Helper, "phi_u");
-            fed.PushVar(Var1Helper, "p"); fed.PushTestFunc(Var1Helper, "phi_p");
+            fed.PushTrialFunc(Var0Helper, "u"); fed.PushTestFunc(Var0Helper, "phi_u");
+            fed.PushTrialFunc(Var1Helper, "p"); fed.PushTestFunc(Var1Helper, "phi_p");
             discr.SetProbDescr(std::move(fed));
         }
         discr.SetDataGatherer(local_data_gatherer);

--- a/examples/Fem/Ani/diffusion.cpp
+++ b/examples/Fem/Ani/diffusion.cpp
@@ -4,10 +4,10 @@
 
 #include "inmost.h"
 #include "anifem++/utils/utils.h"
-#include "carnum/MeshGen/mesh_gen.h"
-#include "carnum/Fem/AniInterface/Fem3Dtet.h"
-#include "carnum/Fem/AniInterface/ForAssembler.h"
-#include "carnum/Fem/Assembler.h"
+#include "anifem++/fem/operations/eval.h"
+#include "anifem++/inmost_interface/elemental_assembler.h"
+#include "anifem++/inmost_interface/assembler.h"
+#include "anifem++/kinsol_interface/SUNNonlinearSolver.h"
 #include <numeric>
 
 using namespace INMOST;
@@ -251,7 +251,7 @@ int main(int argc, char* argv[]){
         NodeLabelsData data;
         for (int i = 0; i < 4; ++i) {
             data.nlbl[i] = (*p.nodes)[i].Integer(BndLabel);
-            data.flbl[i] = (*p.faces)[p.local_face_index[i]].Integer(BndLabel);
+            data.flbl[i] = (*p.faces)[i].Integer(BndLabel);
         }
         p.compute(args, &data);
     };
@@ -261,7 +261,8 @@ int main(int argc, char* argv[]){
     {
         auto Var0Helper = GenerateHelper<FemFix<FEM_P1>>();
         FemExprDescr fed;
-        fed.PushVar(Var0Helper, "u");
+        //fed.PushVar(Var0Helper, "u");
+        fed.PushTrialFunc(Var0Helper, "u");
         fed.PushTestFunc(Var0Helper, "phi_u");
         discr.SetProbDescr(std::move(fed));
     }

--- a/examples/Fem/CMakeLists.txt
+++ b/examples/Fem/CMakeLists.txt
@@ -1,19 +1,19 @@
 project(FemInterfaces)
 
 add_executable(diffusion Ani/diffusion.cpp)
-target_link_libraries(diffusion CarNum Fem_utils)
+target_link_libraries(diffusion AniFem++ Fem_utils)
 
 add_executable(dyn_diffusion Ani/dyn_diffusion.cpp)
-target_link_libraries(dyn_diffusion CarNum Fem_utils stdc++fs)
+target_link_libraries(dyn_diffusion AniFem++ Fem_utils stdc++fs)
 
 add_executable(stokes-navier Ani/StokesNavier.cpp)
-target_link_libraries(stokes-navier CarNum Fem_utils stdc++fs)
+target_link_libraries(stokes-navier AniFem++ Fem_utils stdc++fs)
 
 set(FEM_EXAMPLES diffusion dyn_diffusion stokes-navier)
 
 if (WITH_KINSOL)
     add_executable(bendbeam Ani/BendBeam.cpp)
-    target_link_libraries(bendbeam CarNum Fem_utils stdc++fs)
+    target_link_libraries(bendbeam AniFem++ Fem_utils stdc++fs AFSUNSolver)
     if (WITH_CASADI)
         target_link_libraries(bendbeam casadi)
     endif()

--- a/examples/tutorials/CMakeLists.txt
+++ b/examples/tutorials/CMakeLists.txt
@@ -36,3 +36,6 @@ target_link_libraries(nonlin_elast AniFem++ Fem_utils)
 
 add_executable(nonlin_elast_incompress nonlin_elast_incompress.cpp prob_args.h prob_args.cpp)
 target_link_libraries(nonlin_elast_incompress AniFem++ Fem_utils)
+
+add_executable(elastoplastic elastoplastic.cpp prob_args.h prob_args.cpp)
+target_link_libraries(elastoplastic AniFem++ Fem_utils)

--- a/examples/tutorials/elastoplastic.cpp
+++ b/examples/tutorials/elastoplastic.cpp
@@ -1,0 +1,535 @@
+/* 
+ * This problem generates and solves the elasto-plastic cylinder expansion problem in symmetric formulation (quarter of cylinder is considered).
+ * \f[
+ * \begin{aligned}
+ *   \mathrm{div}\ \sigma (\varepsilon^e) + f   &= 0\    in\  \Omega  \\
+ *      u_x                         &= 0\     on\  \Gamma_{left}
+ *      u_y                         &= 0\     on\  \Gamma_{bottom}
+ *      \sigma \cdot \mathbf{N}     &= q \mathbf{N}\ on\  \Gamma_{internal}\\  
+ *      \sigma \cdot \mathbf{N}     &= 0\    on\  \Gamma_{free}\\
+ *   \sigma                      &= C_{(ij)(kl)} \varepsilon^e_{(kl)}\\
+ *   C_{(ij)(kl)}                &= \lambda \delta_{ij}\delta_{kl} + \mu (\delta_{ik}\delta_{jl} + \delta_{il}\delta_{jk})\\
+ *   \varepsilon &= \varepsilon^e + \varepsilon^p
+ *   \varepsilon &= \frac{1}{2}(\mathrm{grad}\ \mathbf{u} + (\mathrm{grad}\ \mathbf{u})^T)
+ * \end{aligned}
+ * \f]
+ * References:
+ * (1) https://comet-fenics.readthedocs.io/en/latest/demo/2D_plasticity/vonMises_plasticity.py.html
+ * (2) https://github.com/a-latyshev/convex-plasticity/blob/main/tutorials/plasticity/plasticity.ipynb
+*/
+
+#include "prob_args.h"
+#include "anifem++/autodiff/cauchy_strain_autodiff.h"
+
+using namespace INMOST;
+
+double E = 7e4, nu = 0.3; // Young modulus (Pa), Poisson coefficient
+double mu = E/(2*(1+nu)), lambda = E*nu/((1+nu)*(1-2*nu)); // Lame parameters (Pa)
+double Et = E/100; // tangent modulus
+double sigma_yield = 250; // yield strength (Pa)
+double H = E*Et/(E-Et); // hardening modulus
+double Re = 1.3, Ri = 1.; // mesh external and internal radii
+
+struct InputArgs1VarNonLin: public InputArgs1Var{
+    using ParentType = InputArgs1Var;
+    double nlin_rel_err = 1e-8, nlin_abs_err = 1e-8;
+    int nlin_maxit = 10;
+    double lin_abs_scale = 0.01;
+
+    uint parseArg(int argc, char* argv[], bool print_messages = true) override {
+        #define GETARG(X)   if (i+1 < static_cast<uint>(argc)) { X }\
+            else { if (print_messages) std::cerr << "ERROR: Not found argument" << std::endl; exit(-1); }
+        uint i = 0;
+        if (strcmp(argv[i], "-re") == 0 || strcmp(argv[i], "--rel_error") == 0){
+            GETARG(nlin_rel_err = std::stod(argv[++i]);)
+            return i+1; 
+        } if (strcmp(argv[i], "-ae") == 0 || strcmp(argv[i], "--abs_error") == 0){
+            GETARG(nlin_abs_err = std::stod(argv[++i]);)
+            return i+1; 
+        } if (strcmp(argv[i], "-ni") == 0 || strcmp(argv[i], "--maxits") == 0){
+            GETARG(nlin_maxit = std::stoi(argv[++i]);)
+            return i+1; 
+        } if (strcmp(argv[i], "-Re") == 0 || strcmp(argv[i], "--external-radius") == 0){
+            GETARG(Re = std::stod(argv[++i]);)
+            return i+1; 
+        } if (strcmp(argv[i], "-E") == 0 || strcmp(argv[i], "--young-modulus") == 0){
+            GETARG(E = std::stod(argv[++i]);)
+            return i+1;
+        } if (strcmp(argv[i], "-nu") == 0 || strcmp(argv[i], "--poisson-coef") == 0){
+            GETARG(nu = std::stod(argv[++i]);)
+            return i+1;
+        } if (strcmp(argv[i], "-sig0") == 0 || strcmp(argv[i], "--sigma-yield") == 0){
+            GETARG(sigma_yield = std::stod(argv[++i]);)
+            return i+1; 
+        } if (strcmp(argv[i], "-Et") == 0 || strcmp(argv[i], "--tangent-modulus") == 0){
+            GETARG(Et = std::stod(argv[++i]);)
+            H = E*Et/(E-Et);
+            return i+1; 
+        } if (strcmp(argv[i], "--latol_scl") == 0){
+            GETARG(lin_abs_scale = std::stod(argv[++i]);)
+            return i+1; 
+        } else 
+            return ParentType::parseArg(argc, argv, print_messages);
+        #undef GETARG
+    }
+    void print(std::ostream& out = std::cout, const std::string& prefix = "") const override{
+        out << prefix << "newton: stop tolerances: rel_tol = " << nlin_rel_err << ", abs_tol = " << nlin_abs_err << "\n";
+        out << prefix << "newton: maximum iteration number = " << nlin_maxit << "\n";
+        out << prefix << "newton: linear solver absolute tolerance scale = " << lin_abs_scale << "\n";
+        ParentType::print(out, prefix);
+    }
+
+protected:
+    void printArgsDescr(std::ostream& out = std::cout, const std::string& prefix = "") override{
+        out << prefix << "  -re,   --rel_error       DVAL    <Set stop relative residual norm for newton method, default=\"" << nlin_rel_err << "\">\n";
+        out << prefix << "  -ae,   --abs_error       DVAL    <Set stop absolute residual norm for newton method, default=\"" << nlin_abs_err << "\">\n";
+        out << prefix << "  -ni,   --maxits          IVAL    <Set maximum number of newton method iterations, default=\"" << nlin_maxit << "\">\n";
+        out << prefix << "         --latol_scl       IVAL    <Set newton linear solver absolute tolerance scale, default=\"" << lin_abs_scale << "\">\n";
+        out << prefix << "  -Re,   --external-radius DVAL    <Set external radius of cylinder (if mesh was changed), default=\"" << Re << "\">\n";
+        out << prefix << "  -E,    --young-modulus   DVAL    <Set Young modulus of cylinder , default=\"" << E << "\">\n";
+        out << prefix << "  -nu,   --poisson-coef    DVAL    <Set Poisson coefficient of cylinder , default=\"" << nu << "\">\n";
+        out << prefix << "  -sig0, --sigma-yield     DVAL    <Set yield stress (von Mises criterium) , default=\"" << sigma_yield << "\">\n";
+        out << prefix << "  -Et,   --tangent-modulus DVAL    <Set plastic tangent modulus , default=\"" << Et << "\">\n";
+        ParentType::printArgsDescr(out, prefix);
+    }
+};
+
+using namespace Ani;
+struct BndMarker{
+    std::array<int, 4> n = {0};
+    std::array<int, 6> e = {0};
+    std::array<int, 4> f = {0};
+
+    DofT::TetGeomSparsity getSparsity(int type) const {
+        DofT::TetGeomSparsity sp;
+        for (int i = 0; i < 4; ++i) if (n[i] & type)
+            sp.setNode(i);
+        for (int i = 0; i < 6; ++i) if (e[i] & type)
+            sp.setEdge(i);  
+        for (int i = 0; i < 4; ++i) if (f[i] & type)
+            sp.setFace(i);
+        return sp;
+    }
+    void fillFromBndTag(Tag lbl, Ani::DofT::uint geom_mask, const ElementArray<Node>& nodes, const ElementArray<Edge>& edges, const ElementArray<Face>& faces) {
+        if (geom_mask & DofT::NODE){
+            for (unsigned i = 0; i < n.size(); ++i) 
+                n[i] = nodes[i].Integer(lbl);
+        }
+        if (geom_mask & DofT::EDGE){
+            for (unsigned i = 0; i < e.size(); ++i) 
+                e[i] = edges[i].Integer(lbl);
+        }
+        if (geom_mask & DofT::FACE){
+            for (unsigned i = 0; i < f.size(); ++i) 
+                f[i] = faces[i].Integer(lbl);
+        }
+    }
+};
+struct ProbLocData{
+    BndMarker lbl;      //< save labels used to apply boundary conditions
+    ArrayView<> udofs;  //< save elemental dofs to evaluate grad_j u_i (x)
+    ArrayView<> sigma_dofs, alpha_dofs; //< elemental dofs of plastic variables
+
+    //some helper data to be postponed to tensor functions
+    const Tetra<const double>* pXYZ = nullptr;
+    DynMem<>* palloc = nullptr;
+    const Cell* c = nullptr;
+    double time = 0.0;
+};
+
+int main(int argc, char* argv[]){
+    InputArgs1VarNonLin p;
+    std::string prob_name = "elastoplastic";
+    p.save_prefix = prob_name + "_out"; 
+    p.parseArgs_mpi(&argc, &argv);
+    unsigned quad_order = p.max_quad_order;
+
+    int pRank = 0, pCount = 1;
+    InmostInit(&argc, &argv, p.lin_sol_db, pRank, pCount);
+
+    Mesh* m = new Mesh;
+    m->Load("../../../data/mesh/thick_cylinder.msh");
+    
+    // Constructing of Ghost cells in 1 layers connected via nodes is required for FEM Assemble method
+    m->ExchangeGhost(1,NODE);
+    print_mesh_sizes(m);
+
+    //generate FEM space from it's name
+    FemSpace UFem = choose_space_from_name(p.USpace)^3;
+    uint unf = UFem.dofMap().NumDofOnTet();
+    auto& dofmap = UFem.dofMap();
+    uint nquad = tetrahedron_quadrature_formulas(quad_order).GetNumPoints();
+
+    auto mask = GeomMaskToInmostElementType(dofmap.GetGeomMask()) | FACE;
+    const int INTERNAL_PART = 0, FREE_BND = 1, DIRICHLET_BND_U = 2, DIRICHLET_BND_V = 4, PRESSURE_BND = 8, DIRICHLET_BND_W = 16;
+    
+    // Set boundary labels on all boundaries
+    Tag BndLabel = m->CreateTag("bnd_label", DATA_INTEGER, mask, NONE, 1);
+    auto bmrk = m->CreateMarker();
+    m->MarkBoundaryFaces(bmrk);
+    for (auto it = m->BeginElement(mask); it != m->EndElement(); ++it) it->Integer(BndLabel) = INTERNAL_PART;
+    for (auto it = m->BeginFace(); it != m->EndFace(); ++it) if (it->GetMarker(bmrk)) {
+        std::array<double, 3> c, nrm;
+        it->Centroid(c.data()); it->UnitNormal(nrm.data());
+        int lbl = INTERNAL_PART;
+        // left symmetry plane:  u = 0
+        if (fabs(c[0] - 0) < 10*std::numeric_limits<double>::epsilon()) lbl = DIRICHLET_BND_U;
+        // right symmetry plane: v = 0
+        else if (fabs(c[1] - 0) < 10*std::numeric_limits<double>::epsilon()) lbl = DIRICHLET_BND_V;
+        // faces normal to Z:    w = 0
+        else if (fabs(nrm[2]) > 1.0-1.0e-4)
+            lbl = DIRICHLET_BND_W;
+        // external boundary
+        else if (sqrt(c[0]*c[0]+c[1]*c[1]) > 0.5*(::Re+::Ri))
+            lbl = FREE_BND;
+        // internal boundary:    p = p0
+        else 
+            lbl = PRESSURE_BND;
+        auto set_label = [BndLabel, lbl](const auto& elems){
+            for (unsigned ni = 0; ni < elems.size(); ni++)
+                elems[ni].Integer(BndLabel) |= lbl;
+        };
+        if (mask & NODE) set_label(it->getNodes());
+        if (mask & EDGE) set_label(it->getEdges());
+        if (mask & FACE) set_label(it->getFaces());
+    }
+    m->ReleaseMarker(bmrk);
+
+    // Define tag to store result
+    TagRealArray u0 = createFemVarTag(m, *dofmap.target<>(), "u0"); // previous time step value
+    TagRealArray du = createFemVarTag(m, *dofmap.target<>(), "du"); // increment to the previous time step value
+    // storage for additional plastic unknowns
+    TagRealArray tag_alpha = m->CreateTag("tag_alpha", DATA_REAL, CELL, NONE, 2*nquad); // alpha, alpha0
+    TagRealArray tag_sigma = m->CreateTag("tag_sigma", DATA_REAL, CELL, NONE, 2*6*nquad); // sigma, sigma0
+
+    auto comp_gradDeltaU = [gradUFEM = UFem.getOP(GRAD)](const Coord<> &X, const Tetra<const double>& XYZ, Ani::ArrayView<> udofs, DynMem<>& alloc)->Mtx3D<>{
+        Mtx3D<> grU;
+        DenseMatrix<> A(grU.m_dat.data(), 9, 1);
+        fem3DapplyX(XYZ, ArrayView<const double>(X.data(), 3), DenseMatrix<>(udofs.data, udofs.size, 1), gradUFEM, A, alloc);
+        return grU;
+    };
+    auto external_pressure = [](const Cell& c, const Coord<> &X, double time) -> double{
+        (void) c, (void) X;
+        return time*2./sqrt(3)*::sigma_yield*log(::Re/::Ri);
+    };
+    auto sigma_func = [](const SymMtx3D<>& deps){
+        return ::lambda*deps.Trace()*SymMtx3D<>::Identity() + 2*::mu*deps;
+    };
+    // Radial return algorithm 
+    auto compute_plastic = [sigma_func](const SymMtx3D<>& deps, struct ProbLocData& p, SymMtx3D<>& n_elas, SymMtx3D<>& sigma, double& beta, int iQuad, bool jacobian = false)
+    {
+        SymMtx3D<> sig_old;
+        std::copy(p.sigma_dofs.begin()+iQuad*12+0, p.sigma_dofs.begin()+iQuad*12+6, sig_old.begin());
+        auto alpha_n = p.alpha_dofs[iQuad*2+0];
+
+        SymMtx3D<> sig_elas = sig_old + sigma_func(deps);
+        SymMtx3D<> s = sig_elas - sig_elas.Trace()/3 * SymMtx3D<>::Identity();
+        double sig_eq = sqrt(3./2 * s.SquareFrobNorm())+1.0e-20;
+        // linear isotropic hardening law: H(alpha) = sigma_yield + H * alpha
+        double f_elas = sig_eq - (::sigma_yield + ::H*alpha_n);
+        // linear isotropic hardening law leads to analytical expression for dp:
+        double dp = (f_elas + fabs(f_elas))/2 / (3*::mu + ::H);
+        n_elas = (dp > 0) * s / sig_eq;
+        beta = 3*::mu * dp /sig_eq;
+        sigma = sig_elas - beta*s;
+        if(!jacobian) // update plastic variables
+        {
+            p.alpha_dofs[iQuad*2+1] = alpha_n + dp;
+            std::copy(sigma.begin(), sigma.end(), p.sigma_dofs.begin()+iQuad*12+6);
+        }
+    };
+    auto sigma_resid_tensor = [comp_gradDeltaU, compute_plastic](const std::array<double, 3>& x, double *Dmem, TensorDims Ddims, void * user_data, int iQuad){
+        (void) Ddims;
+        auto& p = *static_cast<ProbLocData*>(user_data);
+        auto grDeltaU = comp_gradDeltaU(x, *p.pXYZ, p.udofs, *p.palloc);
+        auto deps = grDeltaU.Sym();
+        double beta; SymMtx3D<> n_elas, sigma;
+        compute_plastic(deps, p, n_elas, sigma, beta, iQuad, false);
+        Mtx3D<> sigma_resid(sigma);
+        std::copy(sigma_resid.m_dat.data(), sigma_resid.m_dat.data() + 9, Dmem);
+        return Ani::TENSOR_GENERAL;
+    };
+    auto sigma_tang_tensor = [comp_gradDeltaU, compute_plastic](const std::array<double, 3>& x, double *Dmem, TensorDims Ddims, void * user_data, int iQuad){
+        (void) Ddims;
+        auto& p = *static_cast<ProbLocData*>(user_data);
+        auto grDeltaU = comp_gradDeltaU(x, *p.pXYZ, p.udofs, *p.palloc);
+        auto deps = grDeltaU.Sym();
+        double beta; SymMtx3D<> n_elas, sigma;
+        compute_plastic(deps, p, n_elas, sigma, beta, iQuad, true);
+        auto sigma_tang = tensor_convert<Tensor4Rank<3>>(
+            (::lambda + 2./3*::mu*beta) * BiSym4Tensor3D<>::TensorSquare(SymMtx3D<>::Identity())
+            + 2*::mu*(1-beta)*BiSym4Tensor3D<>::Identity()
+            - 3*::mu*(1./(1+::H/(3*::mu)) - beta)*BiSym4Tensor3D<>::TensorSquare(n_elas));
+        std::copy(sigma_tang.m_dat.data(), sigma_tang.m_dat.data()+81, Dmem);
+        return Ani::TENSOR_GENERAL;
+    };
+    auto pressure_tensor = [external_pressure](const Coord<> &X, double *F, TensorDims dims, void *user_data, int iQuad){
+        (void) dims; (void) iQuad;
+        auto& p = *static_cast<ProbLocData*>(user_data);
+        double p0 = external_pressure(*p.c, X, p.time);
+        DenseMatrix<> pm(F, 9, 1);
+        pm.SetZero();
+        pm(0 + 0*3, 0) = p0;
+        pm(1 + 1*3, 0) = p0;
+        pm(2 + 2*3, 0) = p0;
+        return Ani::TENSOR_GENERAL;
+    };
+    auto sigma_resid_fuse_tensor = [sigma_resid_tensor](ArrayView<> X, ArrayView<> D, TensorDims Ddims, void *user_data, const AniMemory<>& mem){
+        for(std::size_t r = 0; r < mem.f; ++r) // over tets
+        for(std::size_t n = 0; n < mem.q; ++n) // over quad points
+        {
+            DenseMatrix<> Dloc(D.data + Ddims.first*Ddims.second*(n + mem.q*r), Ddims.first, Ddims.second);
+            sigma_resid_tensor({X.data[3*(n + mem.q*r) + 0], X.data[3*(n + mem.q*r) + 1], X.data[3*(n + mem.q*r) + 2]}, 
+                            Dloc.data, Ddims, user_data, n);
+        }
+        return Ani::TENSOR_GENERAL;
+    };
+    auto sigma_tang_fuse_tensor = [sigma_tang_tensor](ArrayView<> X, ArrayView<> D, TensorDims Ddims, void *user_data, const AniMemory<>& mem){
+        for(std::size_t r = 0; r < mem.f; ++r) // over tets
+        for(std::size_t n = 0; n < mem.q; ++n) // over quad points
+        {
+            DenseMatrix<> Dloc(D.data + Ddims.first*Ddims.second*(n + mem.q*r), Ddims.first, Ddims.second);
+            sigma_tang_tensor({X.data[3*(n + mem.q*r) + 0], X.data[3*(n + mem.q*r) + 1], X.data[3*(n + mem.q*r) + 2]}, 
+                            Dloc.data, Ddims, user_data, n);
+        }
+        return Ani::TENSOR_GENERAL;
+    };
+
+    double T = 0.0;
+    //define function for gathering data from every tetrahedron to send them to elemental assembler
+    auto local_data_gatherer = [&BndLabel, unf, UFem, geom_mask = (UFem.dofMap().GetGeomMask() | DofT::FACE), &T, nquad, tag_sigma, tag_alpha](ElementalAssembler& p) -> void{
+        double *nn_p = p.get_nodes();
+        const double *args[] = {nn_p, nn_p + 3, nn_p + 6, nn_p + 9};
+        ProbLocData data;
+        data.lbl.fillFromBndTag(BndLabel, geom_mask, *p.nodes, *p.edges, *p.faces);
+        data.udofs.Init(p.vars->begin(0), unf);
+        data.c = p.cell;
+        data.time = T;
+        // pull tag storage for plastic variables into user_data
+        Storage::real_array dat_alpha = tag_alpha[*p.cell], dat_sigma = tag_sigma[*p.cell];
+        data.alpha_dofs.Init(dat_alpha.data(), 2*nquad);
+        data.sigma_dofs.Init(dat_sigma.data(), 2*6*nquad);
+
+        p.compute(args, &data);
+    };
+    std::function<void(const double**, double*, double*, long*, void*, DynMem<double, long>*)> local_jacobian_assembler = 
+        [unf, sigma_tang_fuse_tensor, &UFem, grad_u = UFem.getOP(GRAD), order = quad_order](const double** XY/*[4]*/, double* Adat, double* rw, long* iw, void* user_data, DynMem<double, long>* fem_alloc){
+        (void) rw, (void) iw;
+        DenseMatrix<> A(Adat, unf, unf); A.SetZero();
+        auto adapt_alloc = makeAdaptor<double, int>(*fem_alloc);
+        auto Bmem = adapt_alloc.alloc(unf*unf, 0, 0);
+        DenseMatrix<> B(Bmem.getPlainMemory().ddata, unf, unf); B.SetZero();
+        Tetra<const double> XYZ(XY[0], XY[1], XY[2], XY[3]);
+
+        auto& dat = *static_cast<ProbLocData*>(user_data);
+        dat.pXYZ = &XYZ, dat.palloc = &adapt_alloc;
+
+        // elemental stiffness matrix <C grad(P1), grad(P1)> 
+        fem3Dtet<DfuncTraitsFusive<>>(XYZ, grad_u, grad_u, sigma_tang_fuse_tensor, A, adapt_alloc, order, &dat);
+        // Neumann BC are constant, jacobian contribution is zero
+
+        // choose boundary parts of the tetrahedron 
+        DofT::TetGeomSparsity spx = dat.lbl.getSparsity(DIRICHLET_BND_U), spy = dat.lbl.getSparsity(DIRICHLET_BND_V), spz = dat.lbl.getSparsity(DIRICHLET_BND_W);
+        const auto& dofmap = UFem.dofMap();
+        if (!spx.empty())
+        {
+            int ext_dims[2] = {0,2};// x and z displacements are fixed
+            applyDirMatrix(dofmap.GetNestedDofMap(ext_dims+0,1), A, spx);
+            applyDirMatrix(dofmap.GetNestedDofMap(ext_dims+1,1), A, spx);
+        }
+        if (!spy.empty())
+        {
+            int ext_dims[2] = {1,2};// y and z displacements are fixed
+            applyDirMatrix(dofmap.GetNestedDofMap(ext_dims+0,1), A, spy);
+            applyDirMatrix(dofmap.GetNestedDofMap(ext_dims+1,1), A, spy);
+        }
+        if (!spz.empty())
+        {
+            int ext_dims[1] = {2};// z displacement is fixed
+            applyDirMatrix(dofmap.GetNestedDofMap(ext_dims+0,1), A, spz);
+        }
+    };
+    std::function<void(const double**, double*, double*, long*, void*, DynMem<double, long>*)> local_residual_assembler = 
+        [unf, sigma_resid_fuse_tensor, pressure_tensor, &UFem, grad_u = UFem.getOP(GRAD), iden_u = UFem.getOP(IDEN), order = quad_order](const double** XY/*[4]*/, double* Adat, double* rw, long* iw, void* user_data, DynMem<double, long>* fem_alloc){
+        (void) rw, (void) iw;
+        DenseMatrix<> F(Adat, unf, 1); F.SetZero();
+        auto adapt_alloc = makeAdaptor<double, int>(*fem_alloc);
+        auto Bmem = adapt_alloc.alloc(unf, 0, 0);
+        DenseMatrix<> B(Bmem.getPlainMemory().ddata, unf, 1); B.SetZero();
+        Tetra<const double> XYZ(XY[0], XY[1], XY[2], XY[3]);
+
+        auto& dat = *static_cast<ProbLocData*>(user_data);
+        dat.pXYZ = &XYZ, dat.palloc = &adapt_alloc;
+        ApplyOpFromTemplate<IDEN, FemFix<FEM_P0>> iden_p0;
+
+        // elemental stiffness matrix <sigma_resid, grad(P1)> 
+        fem3Dtet<DfuncTraitsFusive<>>(XYZ, iden_p0, grad_u, sigma_resid_fuse_tensor, F, adapt_alloc, order, &dat); 
+        // apply Neumann BC
+        for (int k = 0; k < 4; ++k){
+            if (dat.lbl.f[k] & PRESSURE_BND){ //Neumann BC
+                fem3DfaceN<DfuncTraits<TENSOR_GENERAL>> ( XYZ, k, iden_p0, iden_u, pressure_tensor, B, adapt_alloc, order, &dat);
+                F += B;
+            }
+        }
+
+        // choose boundary parts of the tetrahedron 
+        DofT::TetGeomSparsity spx = dat.lbl.getSparsity(DIRICHLET_BND_U), spy = dat.lbl.getSparsity(DIRICHLET_BND_V), spz = dat.lbl.getSparsity(DIRICHLET_BND_W);
+        const auto& dofmap = UFem.dofMap();
+        if (!spx.empty())
+        {
+            int ext_dims[2] = {0,2};// x and z displacements are fixed
+            applyDirResidual(dofmap.GetNestedDofMap(ext_dims+0,1), F, spx);
+            applyDirResidual(dofmap.GetNestedDofMap(ext_dims+1,1), F, spx);
+        }
+        if (!spy.empty())
+        {
+            int ext_dims[2] = {1,2};// y and z displacements are fixed
+            applyDirResidual(dofmap.GetNestedDofMap(ext_dims+0,1), F, spy);
+            applyDirResidual(dofmap.GetNestedDofMap(ext_dims+1,1), F, spy);
+        }
+        if (!spz.empty())
+        {
+            int ext_dims[1] = {2};// z displacement is fixed
+            applyDirResidual(dofmap.GetNestedDofMap(ext_dims+0,1), F, spz);
+        }
+    };
+
+    //define assembler
+    Assembler discr(m);
+    discr.SetMatFunc(GenerateElemMat(local_jacobian_assembler, unf, unf, 0, 0));
+    discr.SetRHSFunc(GenerateElemRhs(local_residual_assembler, unf, 0, 0));
+    {
+        //create global degree of freedom enumenator
+        auto Var0Helper = GenerateHelper(*UFem.base());
+        FemExprDescr fed;
+        fed.PushTrialFunc(Var0Helper, "u");
+        fed.PushTestFunc(Var0Helper, "phi_u");
+        discr.SetProbDescr(std::move(fed));
+    }
+    discr.SetDataGatherer(local_data_gatherer);
+    discr.PrepareProblem();
+    discr.pullInitValFrom(du);
+
+    //get parallel interval and allocate parallel vectors
+    auto i0 = discr.getBegInd(), i1 = discr.getEndInd();
+    Sparse::Matrix  A( "A" , i0, i1, m->GetCommunicator());
+    Sparse::Vector  x( "x" , i0, i1, m->GetCommunicator()),
+                    dx("dx", i0, i1, m->GetCommunicator()), 
+                    b( "b" , i0, i1, m->GetCommunicator());
+    discr.AssembleTemplate(A);  //< preallocate memory for matrix (to accelerate matrix assembling), this call is optional
+    // set options to use preallocated matrix state (to accelerate matrix assembling)
+    Ani::AssmOpts opts = Ani::AssmOpts().SetIsMtxIncludeTemplate(true)
+                                        .SetUseOrderedInsert(true)
+                                        .SetIsMtxSorted(true); //< setting this parameters is optional
+
+    //setup linear solver
+    Solver lin_solver(p.lin_sol_nm, p.lin_sol_prefix);
+    auto assemble_R = [&discr, &du](const Sparse::Vector& x, Sparse::Vector &b) -> int {
+        discr.SaveSolution(x, du);
+        std::fill(b.Begin(), b.End(), 0.0);
+        return discr.AssembleRHS(b);
+    };
+    auto assemble_J = [&discr, &du, opts](const Sparse::Vector& x, Sparse::Matrix &A) -> int {
+        std::for_each(A.Begin(), A.End(), [](INMOST::Sparse::Row& row){ for (auto vit = row.Begin(); vit != row.End(); ++vit) vit->second = 0.0; });
+        return discr.AssembleMatrix(A, opts);
+    };
+    auto vec_norm = [m](const Sparse::Vector& x)->double {
+        double lsum = 0, gsum = 0;
+        for (auto itx = x.Begin(); itx != x.End(); ++itx)
+            lsum += (*itx) * (*itx);
+        gsum = m->Integrate(lsum);
+        return sqrt(gsum);
+    };
+    auto vec_saxpy = [](double a, const Sparse::Vector& xv, double b, const Sparse::Vector& yv, Sparse::Vector& zv) {
+        auto itz = zv.Begin();
+        for (auto itx = xv.Begin(), ity = yv.Begin();
+            itx != xv.End() && ity != yv.End() && itz != zv.End(); ++itx, ++ity, ++itz)
+            *itz = a * (*itx) + b * (*ity);
+    };
+
+    constexpr int Nincr = 20;
+    // times as in FeniCS example:
+    // import numpy as np; Nincr = 20; np.linspace(0, 1.1, Nincr+1)[1:]**0.5
+    std::array<double,Nincr> times
+        {0.23452079, 0.33166248, 0.40620192, 0.46904158, 0.52440442, \
+         0.57445626, 0.62048368, 0.66332496, 0.70356236, 0.74161985, \
+         0.77781746, 0.81240384, 0.84557673, 0.87749644, 0.90829511, \
+         0.93808315, 0.96695398, 0.99498744, 1.02225242, 1.04880885};
+    int step = 1;
+    std::ofstream ofs("cylinder_load_displacement.csv");
+    if(pRank == 0) ofs << "displacement_inner_boundary;applied_pressure\n";
+    TimerWrap m_timer_total; m_timer_total.reset();
+    while(step < Nincr+1)
+    {
+        T = times[step-1];
+        TimerWrap m_timer_step; m_timer_step.reset();
+        std::fill(x.Begin(), x.End(), 0.0); // x <- 0
+        assemble_R(x, b); // 0 = x -> du, b
+        double anrm = vec_norm(b), rnrm = 1;
+        double anrm0 = anrm;
+        int ni = 0;
+        if (pRank == 0)
+        {
+            double p0 = external_pressure(m->BeginCell()->self(), std::array<double,3>{0,0,0}, T);
+            std::cout << "Start step " << step << ": T " << T << " " << " load " << p0 << std::endl;
+            std::cout << prob_name << ":\n\tnit = " << ni << ": newton residual = " << anrm << " ( rel = " << rnrm << " )" <<  std::endl;
+        }
+        while (rnrm >= p.nlin_rel_err && anrm >= p.nlin_abs_err && ni < p.nlin_maxit){
+            assemble_J(x, A);
+            lin_solver.SetMatrix(A); // x -> du, A
+            if (std::stod(lin_solver.GetParameter("absolute_tolerance")) > p.lin_abs_scale*anrm)
+               lin_solver.SetParameterReal("absolute_tolerance", p.lin_abs_scale*anrm);
+            lin_solver.Solve(b, dx);
+            print_linear_solver_status(lin_solver, prob_name, true);
+            vec_saxpy(1, x, -1, dx, x); // x = b <- x - dx
+            assemble_R(x, b); // x -> du, b
+            anrm = vec_norm(b);
+            rnrm = anrm / anrm0;
+            ni++;
+            if (pRank == 0) std::cout << prob_name << ":\n\tnit = " << ni << ": newton residual = " << anrm << " ( rel = " << rnrm << " )" <<  std::endl;
+        }
+        {
+            // update plastic variables
+            for(int k = 0; k < m->CellLastLocalID(); ++k) if(m->isValidCell(k))
+            {
+                Cell c = m->CellByLocalID(k);
+                Storage::real_array dat_alpha = tag_alpha[c];
+                Storage::real_array dat_sigma = tag_sigma[c];
+                for(std::size_t iQuad = 0; iQuad < nquad; ++iQuad)
+                {
+                    dat_alpha[2*iQuad+0] = dat_alpha[2*iQuad+1];
+                    std::copy(dat_sigma.data()+iQuad*12+6, dat_sigma.data()+iQuad*12+12, dat_sigma.data()+iQuad*12);
+                }
+            }
+            // u0 <- u0 + du
+            discr.SaveSolution(u0, b); // u0 -> b
+            vec_saxpy(1, b, +1, x, x); // x  <- b + x = u0 + du
+            discr.SaveSolution(x, u0); // u0 <- x     = u0 + du
+        }
+        double u_max = -1.0;
+        for(int k = 0; k < m->NodeLastLocalID(); ++k) if(m->isValidNode(k))
+        {
+            Storage::real_array u_node = u0[m->NodeByLocalID(k)];
+            double ur = sqrt(u_node[0]*u_node[0] + u_node[1]*u_node[1]);
+            if(ur > u_max) u_max = ur;
+        }
+        m->AggregateMax(u_max);
+        if(pRank == 0)
+        {
+            std::cout << "Finished step " << step << std::endl;
+            ofs << u_max << ';' << T << '\n';
+        }
+        m->Save(p.save_dir + p.save_prefix + "_" + std::to_string(step-1) + ".vtk");
+        ++step;
+        double step_sol_time =  m_timer_step.elapsed();
+        if (pRank == 0) std::cout << "Step solution time: " << step_sol_time << "s" << std::endl;
+    }
+    double total_sol_time =  m_timer_total.elapsed();
+    if (pRank == 0) std::cout << "Total solution time: " << total_sol_time << "s" << std::endl;
+
+    discr.Clear();
+    delete m;
+    InmostFinalize();
+
+    return 0;
+}

--- a/examples/tutorials/lin_elast.cpp
+++ b/examples/tutorials/lin_elast.cpp
@@ -103,7 +103,7 @@ int main(int argc, char* argv[]){
         (void) X; (void) dims; (void) user_data; (void) iTet;
         DenseMatrix<> C(D, 9, 9); 
         double lambda = 1.0, mu = 3.0;
-        //C_{(ij)(kl)} = \lambda \detla_{ij}\delta_{kl} + \mu (\detla_{ik}\delta_{jl} + \detla_{il}\delta_{jk})
+        //C_{(ij)(kl)} = \lambda \delta_{ij}\delta_{kl} + \mu (\delta_{ik}\delta_{jl} + \delta_{il}\delta_{jk})
         C.SetZero();
         for (int i = 0; i < 3; ++i)      
             for (int l = 0; l < 3; ++l){ 

--- a/examples/tutorials/nonlin_elast.cpp
+++ b/examples/tutorials/nonlin_elast.cpp
@@ -292,7 +292,7 @@ int main(int argc, char* argv[]){
         Tetra<const double> XYZ(XY[0], XY[1], XY[2], XY[3]);
         auto& d = *static_cast<ProbLocData*>(user_data);
         d.pXYZ = &XYZ, d.palloc = &adapt_alloc;
-        auto grad_u = UFem.getOP(GRAD), iden_u = UFem.getOP(IDEN);  
+        //auto grad_u = UFem.getOP(GRAD), iden_u = UFem.getOP(IDEN);
         ApplyOpFromTemplate<IDEN, FemFix<FEM_P0>> iden_p0;  
 
         // elemental stiffness matrix <P, grad(P1)> 

--- a/examples/tutorials/nonlin_elast_incompress.cpp
+++ b/examples/tutorials/nonlin_elast_incompress.cpp
@@ -336,7 +336,7 @@ int main(int argc, char* argv[]){
         Tetra<const double> XYZ(XY[0], XY[1], XY[2], XY[3]);
         auto& d = *static_cast<ProbLocData*>(user_data);
         d.pXYZ = &XYZ, d.palloc = &adapt_alloc;
-        auto grad_u = UFem.getOP(GRAD), iden_u = UFem.getOP(IDEN), iden_p = PFem.getOP(IDEN);  
+        auto iden_p = PFem.getOP(IDEN);
         ApplyOpFromTemplate<IDEN, FemFix<FEM_P0>> iden_p0;  
 
         // elemental stiffness matrix <P, grad(P2^3)> 

--- a/examples/tutorials/quadrature_function.cpp
+++ b/examples/tutorials/quadrature_function.cpp
@@ -189,9 +189,7 @@ int main(int argc, char* argv[]){
                 mptr->Enumerate(NODE, dup_gid); //< save node enumeration
             }
             RepartMesh(mptr.get()); //< divide the mesh between processors
-            if (!mptr->GlobalIDTag().isValid()) {
-                mptr->AssignGlobalID(NODE|EDGE|FACE|CELL);
-            }
+            mptr->AssignGlobalID(NODE|EDGE|FACE|CELL);
 
                 if (!mptr->HaveTag(p.func_name))
                     throw std::runtime_error("Loaded mesh from file \"" + p.mesh_file + "\" does't have tag \"" + p.func_name + "\"");


### PR DESCRIPTION
Добавлен пример с обжатием упругопластичного цилиндра, основанный на [примере на FeniCS](https://comet-fenics.readthedocs.io/en/latest/demo/2D_plasticity/vonMises_plasticity.py.html), работает с MPI и OpenMP.

Исправлены некоторые предупреждения компиляции под clang, мозолящие глаз, исправлены ошибки компиляции примеров из examples/Ani, добавлено пара функций для 3д-тензоров